### PR TITLE
Adds clearTimeout on notification drag

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ class LocalNotification extends Component {
         Math.abs(gestureState.dx) > 100 || Math.abs(gestureState.dy) > 1,
       onPanResponderGrant: (evt, gestureState) => {
         this.textHeightSetCurrentTouch = false;
+        timer.clearTimeout('duration');
       },
       onPanResponderMove: (evt, gestureState) => {
         if (this.state.textHeight < this.fullTextHeight && gestureState.dy > 0) {
@@ -89,12 +90,10 @@ class LocalNotification extends Component {
           if (this.state.topMargin > 0) {
             LayoutAnimation.easeInEaseOut();
             this.setState({ topMargin: 0 });
-            timer.clearTimeout('duration');
           }
           else if (this.state.textHeight < this.fullTextHeight && this.state.topMargin >= 0) {
             LayoutAnimation.easeInEaseOut();
             this.setState({ textHeight: this.fullTextHeight });
-            timer.clearTimeout('duration');
           }
           else if (this.state.topMargin < 0){
             this.hideNotification();


### PR DESCRIPTION
Today if you drag on a notification it will still disappear after 3 sec. This removes it so if you drag the notification it will still be there until you swipe it away or press it